### PR TITLE
Implement node path history tracing

### DIFF
--- a/settings/examples/randomwalk-epidemic_settings.cfg
+++ b/settings/examples/randomwalk-epidemic_settings.cfg
@@ -1,0 +1,50 @@
+## Test scenario using Prophet router and Points of Interest (POIs)
+#===========================================================================
+# SCENARIO CONFIGURATION
+#===========================================================================
+Scenario.name = RandomWalk-%%Group.router%%
+Scenario.nrofHostGroups = 1
+
+#===========================================================================
+# GROUP SPECIFIC SETTINGS
+#===========================================================================
+Group.router = EpidemicRouter
+Group.movementModel = RandomWalk
+Group.nrofHosts = 40
+
+[ Group 1 (pedestrian) ]
+Group1.groupID = p
+
+#===========================================================================
+# EVENTS SETTINGS
+#===========================================================================
+[ General events parameters ]
+Events.nrof = 1
+
+[ Events 1: MessageEventGenerator specific ]
+Events1.class = MessageEventGenerator
+# Creation interval in seconds (one new message every 25 to 35 seconds)
+Events1.interval = 25,35
+# Message sizes (500kB - 1MB)
+Events1.size = 500k,1M
+# range of message source/destination addresses
+Events1.hosts = 0,39
+# Message ID prefix
+Events1.prefix = M
+
+#===========================================================================
+# MOVEMENT SETTINGS
+#===========================================================================
+[ Movement model settings ]
+# seed for movement models' pseudo random number generator (default = 0)
+MovementModel.rngSeed = 1
+# World's size for Movement Models without implicit size (width, height; meters)
+MovementModel.worldSize = 1000, 1000
+# How long time to move hosts in the world before real simulation
+MovementModel.warmup = 1000
+
+#===========================================================================
+# ROUTER SETTINGS
+#===========================================================================
+[ ProphetRouter ]
+ProphetRouter.secondsInTimeUnit = 30

--- a/src/core/Coord.java
+++ b/src/core/Coord.java
@@ -152,4 +152,15 @@ public class Coord implements Cloneable, Comparable<Coord> {
 			return 0;
 		}
 	}
+
+	/**
+	 * Checks whether two coordinates are close enough to be considered close.
+	 * @param c1 First coordinate
+	 * @param c2 Second coordinate
+	 * @param range The range the coordinates are considered close
+	 * @return boolean
+	 */
+	public static boolean areClose(Coord c1, Coord c2, double range) {
+		return Math.abs(c1.getX() - c2.getX()) < range && Math.abs(c1.getY() - c2.getY()) < range;
+	}
 }

--- a/src/core/DTNHost.java
+++ b/src/core/DTNHost.java
@@ -460,6 +460,9 @@ public class DTNHost implements Comparable<DTNHost> {
             }
         }
 
+        /* Path trace purposes: adds the current path to the history */
+        pathHistory.add(path);
+
         return true;
     }
 

--- a/src/core/DTNHost.java
+++ b/src/core/DTNHost.java
@@ -4,8 +4,12 @@
  */
 package core;
 
+import java.awt.*;
 import java.util.*;
+import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
 import movement.MovementModel;
 import movement.Path;
 import routing.MessageRouter;
@@ -35,6 +39,10 @@ public class DTNHost implements Comparable<DTNHost> {
     private List<MovementListener> movListeners;
     private List<NetworkInterface> net;
     private ModuleCommunicationBus comBus;
+
+    /* Path tracing purposes */
+    @Getter @Setter private List<Path> pathHistory;
+	@Getter @Setter private Color hostPathColor;
 
     // tambahan testing
     public List<Duration> intervals;
@@ -105,6 +113,10 @@ public class DTNHost implements Comparable<DTNHost> {
                 l.initialLocation(this, this.location);
             }
         }
+
+        /* Path tracing purposes */
+        this.pathHistory = new LinkedList<>();
+        this.hostPathColor = generateRandomColor();
 
         // tambahan
         // this.setNode = new HashSet<DTNHost>();
@@ -563,7 +575,15 @@ public class DTNHost implements Comparable<DTNHost> {
         return this.getAddress() - h.getAddress();
     }
 
-    /**
+    private Color generateRandomColor() {
+        Random rand = new Random();
+        int r = rand.nextInt(256);
+        int g = rand.nextInt(256);
+        int b = rand.nextInt(256);
+        return new Color(r, g, b);
+    }
+
+	/**
      * Method tambahan untuk menambah Duration ke list
      */
     public void addDuration(Duration dur) {

--- a/src/gui/SimMenuBar.java
+++ b/src/gui/SimMenuBar.java
@@ -49,6 +49,7 @@ public class SimMenuBar extends JMenuBar implements ActionListener {
 	private JCheckBoxMenuItem enableNodeName;
 	private JCheckBoxMenuItem enableNodeCoverage;
 	private JCheckBoxMenuItem enableNodeConnections;
+	private JCheckBoxMenuItem enableNodePathTrace;
 	private JCheckBoxMenuItem enableMapGraphic;
 	private JCheckBoxMenuItem autoClearOverlay;
 	private JMenuItem clearOverlay;
@@ -72,10 +73,9 @@ public class SimMenuBar extends JMenuBar implements ActionListener {
 			enableBgImage = createCheckItem(pfMenu,"Show underlay image",false);
 		}
 		enableNodeName = createCheckItem(pfMenu, "Show node name string",true);
-		enableNodeCoverage = createCheckItem(pfMenu, 
-				"Show node radio coverage", true);
-		enableNodeConnections = createCheckItem(pfMenu,
-				"Show node's connections", true);
+		enableNodeCoverage = createCheckItem(pfMenu, "Show node radio coverage", true);
+		enableNodeConnections = createCheckItem(pfMenu,	"Show node's connections", true);
+		enableNodePathTrace = createCheckItem(pfMenu, "Show node path trace (laggy)", false);
 		enableMapGraphic = createCheckItem(pfMenu,"Show map graphic",true);
 		autoClearOverlay = createCheckItem(pfMenu, "Autoclear overlay",true);
 		clearOverlay = createMenuItem(pfMenu,"Clear overlays now");
@@ -107,16 +107,16 @@ public class SimMenuBar extends JMenuBar implements ActionListener {
 			toggleUnderlayImage();
 		}
 		else if (source == this.enableNodeName) {
-			gui.playfield.NodeGraphic.setDrawNodeName(
-					enableNodeName.isSelected());
+			gui.playfield.NodeGraphic.setDrawNodeName(enableNodeName.isSelected());
 		}
 		else if (source == this.enableNodeCoverage) {
-			gui.playfield.NodeGraphic.setDrawCoverage(
-					enableNodeCoverage.isSelected());
+			gui.playfield.NodeGraphic.setDrawCoverage(enableNodeCoverage.isSelected());
 		}
 		else if (source == this.enableNodeConnections) {
-			gui.playfield.NodeGraphic.setDrawConnections(
-					enableNodeConnections.isSelected());
+			gui.playfield.NodeGraphic.setDrawConnections(enableNodeConnections.isSelected());
+		}
+		else if (source == this.enableNodePathTrace) {
+			field.setShowNodePathTrace(enableNodePathTrace.isSelected());
 		}
 		else if (source == this.enableMapGraphic) {
 			field.setShowMapGraphic(enableMapGraphic.isSelected());
@@ -128,8 +128,8 @@ public class SimMenuBar extends JMenuBar implements ActionListener {
 			field.clearOverlays();
 		}
 		else if (source == this.about) {
-			JOptionPane.showMessageDialog(this, ABOUT_TEXT, ABOUT_TITLE, 
-					JOptionPane.INFORMATION_MESSAGE);
+			JOptionPane
+				.showMessageDialog(this, ABOUT_TEXT, ABOUT_TITLE, JOptionPane.INFORMATION_MESSAGE);
 		}
 		
 	}

--- a/src/gui/playfield/PathGraphic.java
+++ b/src/gui/playfield/PathGraphic.java
@@ -16,7 +16,8 @@ import core.Coord;
  *
  */
 public class PathGraphic extends PlayFieldGraphic {
-	private final static Color PATH_COLOR = Color.RED;
+	private final static Color DEFAULT_PATH_COLOR = Color.RED;
+	private Color pathColor;
 	private List<Coord> coords;
 	
 	public PathGraphic(Path path) {
@@ -27,6 +28,17 @@ public class PathGraphic extends PlayFieldGraphic {
 			this.coords = path.getCoords();
 			assert this.coords != null && this.coords.size() > 0 : 
 			"No coordinates in the path (" + path + ")";
+		}
+	}
+
+	/** Constructor with {@link #pathColor}. */
+	public PathGraphic(Path path, Color pathColor) {
+		this(path);
+		if (pathColor != null) {
+			this.pathColor = pathColor;
+		}
+		else {
+			this.pathColor = DEFAULT_PATH_COLOR;
 		}
 	}
 	
@@ -40,7 +52,7 @@ public class PathGraphic extends PlayFieldGraphic {
 			return;
 		}
 		
-		g2.setColor(PATH_COLOR);
+		g2.setColor(pathColor);
 		Coord prev = coords.get(0);
 		
 		for (int i=1, n=coords.size(); i < n; i++) {

--- a/src/movement/Path.java
+++ b/src/movement/Path.java
@@ -17,7 +17,10 @@ public class Path  {
 	private List<Coord> coords;
 	/** speeds in the path legs */
 	private List<Double> speeds;
+	/** Storing the index of the next waypoint coordinate */
 	private int nextWpIndex;
+	/** Flag variable to check whether the node has completely traveled this path */
+	private boolean isComplete;
 	
 	/**
 	 * Creates a path with zero speed.
@@ -26,6 +29,7 @@ public class Path  {
 		this.nextWpIndex = 0;
 		this.coords = new ArrayList<Coord>();
 		this.speeds = new ArrayList<Double>(1);
+		this.isComplete = false;
 	}
 
 	/**
@@ -37,6 +41,7 @@ public class Path  {
 		this.nextWpIndex = path.nextWpIndex;
 		this.coords = new ArrayList<Coord>((ArrayList<Coord>)path.coords);
 		this.speeds = new ArrayList<Double>((ArrayList<Double>)path.speeds);
+		this.isComplete = path.isComplete;
 	}
 	
 	/**
@@ -92,6 +97,39 @@ public class Path  {
 	public Coord getNextWaypoint() {
 		assert hasNext() : "Path didn't have " + (nextWpIndex+1) + ". waypoint";
 		return coords.get(nextWpIndex++);
+	}
+
+	/**
+	 * Returns the first waypoint on this path.
+	 * @return the first waypoint
+	 */
+	public Coord getFirstWaypoint() {
+		assert hasNext() : "Path didn't have " + (nextWpIndex+1) + ". waypoint";
+		return coords.getFirst();
+	}
+
+	/**
+	 * Returns the last waypoint on this path.
+	 * @return the last waypoint
+	 */
+	public Coord getLastWaypoint() {
+		assert nextWpIndex != 0 : "No waypoint asked";
+		return coords.getLast();
+	}
+
+	/**
+	 * Returns true if the path has been completely traveled.
+	 * @return boolean
+	 */
+	public boolean isComplete() {
+		return this.isComplete;
+	}
+
+	/**
+	 * Sets the path as completely traveled.
+	 */
+	public void setComplete() {
+		this.isComplete = true;
 	}
 	
 	/**


### PR DESCRIPTION
This tracing works by tailing the previous paths and the relative latest path of a host. Each host stores a history of path, and will be randomly assigned a color.

Issue:
- Paths that are generated in bulk e.g. using DijkstraPathFinder in MapRouteMovement won't render the trace properly as the engine weren't able to properly update the state of the last path before a bulk path insertion.

This however, works for random waypoint or randomwalks that inserts path incrementally. Other movements that appends one path at a time works such as Levy Walk/Flight, Crowd movements, etc.

Extra:
- Added demo configuration for RandomWalk.

Demo:

https://github.com/user-attachments/assets/36fe82e1-a79d-4cb7-a07a-eefcc77462d3

